### PR TITLE
Closes #20

### DIFF
--- a/alchemiscale_fah/compute/models.py
+++ b/alchemiscale_fah/compute/models.py
@@ -83,14 +83,18 @@ class ProjectData(FahAdaptiveSamplingModel):
     @field_validator("timeout", mode="before")
     def validate_timeout(cls, v, values, **kwargs):
         if v < 300:
-            raise ValueError("`timeout` must not be less than 300; it will be interpreted as days if so")
+            raise ValueError(
+                "`timeout` must not be less than 300; it will be interpreted as days if so"
+            )
 
         return v
 
     @field_validator("deadline", mode="before")
     def validate_deadline(cls, v, values, **kwargs):
         if v < 300:
-            raise ValueError("`deadline` must not be less than 300; it will be interpreted as days if so")
+            raise ValueError(
+                "`deadline` must not be less than 300; it will be interpreted as days if so"
+            )
 
         return v
 

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -57,6 +57,9 @@ dependencies:
   - plyvel
   - zstandard
 
+  ## pins due to breaking changes
+  - openff-interchange =0.4.1    # https://github.com/openmm/openmmforcefields/issues/365
+
   - pip:
     - git+https://github.com/OpenFreeEnergy/alchemiscale
     - git+https://github.com/datryllic/grolt # neo4j test server deployment


### PR DESCRIPTION
Closes #20 by changing expectations of `ProjectData` `deadline` and `timeout` fields, adding validation to avoid setting to values interpreted as days by the work server.
